### PR TITLE
Оптимизация runtime CLI-скриптов без импорта app.py

### DIFF
--- a/utils/traffic_sync.py
+++ b/utils/traffic_sync.py
@@ -1,34 +1,1075 @@
 #!/usr/bin/env python3
-"""Background traffic snapshot sync for AdminAntizapret.
+"""Fast traffic snapshot sync for AdminAntizapret.
 
-Reads OpenVPN *-status.log files and persists per-user traffic deltas
-into SQLite so data is kept even after clients disconnect.
+This is a lightweight replacement for utils/traffic_sync.py.
+
+It intentionally does NOT import app.py, Flask, SQLAlchemy, routes, schedulers,
+or the full services bundle. It reads OpenVPN status logs and `wg show all dump`,
+then persists traffic deltas directly into SQLite.
+
+Default DB path matches Flask-SQLAlchemy sqlite:///users.db:
+    /opt/AdminAntizapret/instance/users.db
+
+Exit codes:
+    0 - success
+    1 - runtime error
 """
 
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
 import sys
-import logging
+import time
+from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+import warnings
+warnings.filterwarnings(
+    "ignore",
+    category=DeprecationWarning,
+    message=r"datetime\.datetime\.utcnow\(\) is deprecated.*",
+)
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
-if str(ROOT_DIR) not in sys.path:
-    sys.path.insert(0, str(ROOT_DIR))
+INSTANCE_DB = ROOT_DIR / "instance" / "users.db"
+FALLBACK_DB = ROOT_DIR / "users.db"
 
-from app import app, _collect_status_rows_for_snapshot, _persist_traffic_snapshot
+DEFAULT_LOGS_DIR = "/etc/openvpn/server/logs"
+DEFAULT_STATUS_LOG_FILES = {
+    "antizapret-tcp": os.path.join(DEFAULT_LOGS_DIR, "antizapret-tcp-status.log"),
+    "antizapret-udp": os.path.join(DEFAULT_LOGS_DIR, "antizapret-udp-status.log"),
+    "vpn-tcp": os.path.join(DEFAULT_LOGS_DIR, "vpn-tcp-status.log"),
+    "vpn-udp": os.path.join(DEFAULT_LOGS_DIR, "vpn-udp-status.log"),
+}
+DEFAULT_WIREGUARD_CONFIG_FILES = {
+    "antizapret": "/etc/wireguard/antizapret.conf",
+    "vpn": "/etc/wireguard/vpn.conf",
+}
+DEFAULT_WIREGUARD_ACTIVE_HANDSHAKE_SECONDS = 180
+DEFAULT_WIREGUARD_PEER_CACHE_SYNC_MIN_INTERVAL_SECONDS = 300
 
 
-logger = logging.getLogger(__name__)
+def utcnow_sql() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")
 
 
-def run_sync() -> int:
-    with app.app_context():
-        status_rows = _collect_status_rows_for_snapshot()
-        _persist_traffic_snapshot(status_rows)
-    return 0
+def dt_sql(dt: Optional[datetime] = None) -> str:
+    return (dt or datetime.utcnow()).strftime("%Y-%m-%d %H:%M:%S.%f")
+
+
+def env_int(key: str, default: int, min_value: Optional[int] = None) -> int:
+    try:
+        value = int(os.getenv(key, str(default)))
+    except (TypeError, ValueError):
+        value = int(default)
+    if min_value is not None and value < int(min_value):
+        value = int(min_value)
+    return value
+
+
+def resolve_db_path(explicit: Optional[str] = None) -> Path:
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    env_db = (os.getenv("ADMIN_ANTIZAPRET_DB_PATH") or os.getenv("SQLITE_DB_PATH") or "").strip()
+    if env_db:
+        return Path(env_db).expanduser().resolve()
+    if INSTANCE_DB.exists():
+        return INSTANCE_DB
+    return FALLBACK_DB
+
+
+def connect_db(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path), timeout=30)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=30000")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def human_bytes(value: int) -> str:
+    size = float(value or 0)
+    units = ["B", "KB", "MB", "GB", "TB"]
+    idx = 0
+    while size >= 1024 and idx < len(units) - 1:
+        size /= 1024
+        idx += 1
+    precision = 0 if idx == 0 else (2 if size < 10 else 1)
+    return f"{size:.{precision}f} {units[idx]}"
+
+
+def normalize_openvpn_endpoint(endpoint: str) -> str:
+    return re.sub(r"^(?:tcp|udp)\d(?:-server)?:", "", (endpoint or "").strip(), flags=re.IGNORECASE)
+
+
+def extract_ip_from_openvpn_address(address: str) -> str:
+    normalized = normalize_openvpn_endpoint(address)
+    if not normalized:
+        return normalized
+
+    if normalized.startswith("["):
+        m_v6 = re.match(r"^\[([^\]]+)\](?::\d+)?$", normalized)
+        if m_v6:
+            return m_v6.group(1)
+
+    if ":" in normalized:
+        host_part, maybe_port = normalized.rsplit(":", 1)
+        if maybe_port.isdigit():
+            return host_part
+
+    return normalized
+
+
+def extract_ip_from_wireguard_endpoint(endpoint: str) -> str:
+    value = (endpoint or "").strip()
+    if not value or value == "(none)":
+        return ""
+
+    if value.startswith("["):
+        m_v6 = re.match(r"^\[([^\]]+)\](?::\d+)?$", value)
+        if m_v6:
+            return m_v6.group(1)
+
+    if ":" in value:
+        host_part, maybe_port = value.rsplit(":", 1)
+        if maybe_port.isdigit():
+            return host_part
+
+    return value
+
+
+def profile_meta(profile_key: str) -> Dict[str, str]:
+    is_antizapret = profile_key.startswith("antizapret")
+    is_tcp = "-tcp" in profile_key
+    is_wireguard = profile_key.endswith("-wg")
+    return {
+        "network": "Antizapret" if is_antizapret else "VPN",
+        "transport": "TCP" if is_tcp else "UDP",
+        "protocol": "WireGuard" if is_wireguard else "OpenVPN",
+    }
+
+
+def normalize_wireguard_allowed_ip(token: str) -> str:
+    value = (token or "").strip()
+    if not value or value.lower() == "(none)":
+        return ""
+    return value.split("/", 1)[0].strip()
+
+
+def split_wireguard_allowed_ips(value: str) -> List[str]:
+    out: List[str] = []
+    for token in (value or "").split(","):
+        ip = normalize_wireguard_allowed_ip(token)
+        if ip:
+            out.append(ip)
+    return out
+
+
+def is_wireguard_peer_active(latest_handshake_ts: int, active_seconds: int) -> bool:
+    handshake_ts = int(latest_handshake_ts or 0)
+    if handshake_ts <= 0:
+        return False
+    if active_seconds <= 0:
+        return True
+    return max(int(time.time()) - handshake_ts, 0) <= active_seconds
+
+
+def read_status_file(profile_key: str, filename: str) -> Dict[str, Any]:
+    path = Path(filename)
+    try:
+        raw = path.read_text(encoding="utf-8", errors="ignore")
+    except FileNotFoundError:
+        raw = ""
+    except OSError:
+        raw = ""
+
+    updated_at_ts = 0
+    try:
+        updated_at_ts = int(path.stat().st_mtime) if path.exists() else 0
+    except OSError:
+        updated_at_ts = 0
+
+    return {
+        "raw": raw,
+        "updated_at_ts": updated_at_ts,
+        "source_name": path.name,
+    }
+
+
+def parse_status_log(profile_key: str, filename: str) -> Dict[str, Any]:
+    source = read_status_file(profile_key, filename)
+    raw = source.get("raw", "")
+    meta = profile_meta(profile_key)
+
+    if not raw:
+        return {
+            "profile": profile_key,
+            "label": f"{meta['network']} {meta['transport']}",
+            "protocol": meta["protocol"],
+            "filename": source.get("source_name", os.path.basename(filename)),
+            "exists": False,
+            "snapshot_time": "-",
+            "updated_at": "-",
+            "client_count": 0,
+            "unique_real_ips": 0,
+            "total_received": 0,
+            "total_sent": 0,
+            "clients": [],
+        }
+
+    time_match = re.search(r"TIME,([^,\n]+),(\d{10,})", raw)
+    if time_match:
+        snapshot_time = time_match.group(1).strip()
+    else:
+        time_match_tab = re.search(
+            r"^TIME\s+(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\s+(\d{10,})$",
+            raw,
+            re.MULTILINE,
+        )
+        snapshot_time = time_match_tab.group(1).strip() if time_match_tab else "-"
+
+    updated_ts = int(source.get("updated_at_ts") or 0)
+    updated_at = datetime.fromtimestamp(updated_ts).strftime("%Y-%m-%d %H:%M:%S") if updated_ts > 0 else "-"
+
+    clients: List[Dict[str, Any]] = []
+
+    client_pattern = re.compile(
+        r"CLIENT_LIST,([^,\n]+),([^,\n]+),([^,\n]*),([^,\n]*),(\d+),(\d+),([^,\n]+),(\d+),([^,\n]*),([^,\n]*),([^,\n]*),([^,\n\r ]+)"
+    )
+
+    for match in client_pattern.finditer(raw):
+        common_name = match.group(1).strip()
+        real_address = match.group(2).strip()
+        virtual_address = match.group(3).strip()
+        bytes_received = int(match.group(5) or 0)
+        bytes_sent = int(match.group(6) or 0)
+        connected_since = match.group(7).strip()
+        connected_since_ts = int(match.group(8) or 0)
+        cipher = match.group(12).strip()
+
+        clients.append(
+            {
+                "common_name": common_name,
+                "real_address": real_address,
+                "real_ip": extract_ip_from_openvpn_address(real_address),
+                "virtual_address": virtual_address,
+                "session_kind": "openvpn",
+                "bytes_received": bytes_received,
+                "bytes_sent": bytes_sent,
+                "total_bytes": bytes_received + bytes_sent,
+                "connected_since": connected_since,
+                "connected_since_ts": connected_since_ts,
+                "cipher": cipher,
+            }
+        )
+
+    if not clients:
+        client_pattern_tab = re.compile(
+            r"^CLIENT_LIST\s+(\S+)\s+(\S+)\s+(\S+)\s+(?:(\S+)\s+)?(\d+)\s+(\d+)\s+"
+            r"(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\s+(\d+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\S+)",
+            re.MULTILINE,
+        )
+
+        for match in client_pattern_tab.finditer(raw):
+            common_name = match.group(1).strip()
+            real_address = match.group(2).strip()
+            virtual_address = match.group(3).strip()
+            bytes_received = int(match.group(5) or 0)
+            bytes_sent = int(match.group(6) or 0)
+            connected_since = match.group(7).strip()
+            connected_since_ts = int(match.group(8) or 0)
+            cipher = match.group(12).strip()
+
+            clients.append(
+                {
+                    "common_name": common_name,
+                    "real_address": real_address,
+                    "real_ip": extract_ip_from_openvpn_address(real_address),
+                    "virtual_address": virtual_address,
+                    "session_kind": "openvpn",
+                    "bytes_received": bytes_received,
+                    "bytes_sent": bytes_sent,
+                    "total_bytes": bytes_received + bytes_sent,
+                    "connected_since": connected_since,
+                    "connected_since_ts": connected_since_ts,
+                    "cipher": cipher,
+                }
+            )
+
+    clients.sort(key=lambda x: int(x.get("total_bytes") or 0), reverse=True)
+
+    total_received = sum(int(c.get("bytes_received") or 0) for c in clients)
+    total_sent = sum(int(c.get("bytes_sent") or 0) for c in clients)
+    unique_real_ips = len({c.get("real_ip") for c in clients if c.get("real_ip")})
+
+    return {
+        "profile": profile_key,
+        "label": f"{meta['network']} {meta['transport']}",
+        "protocol": meta["protocol"],
+        "filename": source.get("source_name", os.path.basename(filename)),
+        "exists": True,
+        "snapshot_time": snapshot_time,
+        "updated_at": updated_at,
+        "client_count": len(clients),
+        "unique_real_ips": unique_real_ips,
+        "total_received": total_received,
+        "total_sent": total_sent,
+        "clients": clients,
+    }
+
+
+def parse_wireguard_config_peer_rows(config_path: str, interface_name: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    try:
+        raw_lines = Path(config_path).read_text(encoding="utf-8", errors="ignore").splitlines()
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return []
+
+    pending_client_name = ""
+    current_peer: Optional[Dict[str, str]] = None
+
+    def flush_peer(peer_state: Optional[Dict[str, str]]) -> None:
+        if not peer_state:
+            return
+        peer_key = (peer_state.get("peer_public_key") or "").strip()
+        client_name = (peer_state.get("client_name") or "").strip()
+        if not peer_key or not client_name:
+            return
+        rows.append(
+            {
+                "interface_name": interface_name,
+                "peer_public_key": peer_key,
+                "client_name": client_name,
+                "allowed_ips": (peer_state.get("allowed_ips") or "").strip() or None,
+            }
+        )
+
+    for raw_line in raw_lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        m_client = re.match(r"^#\s*Client\s*=\s*(.+)$", line, flags=re.IGNORECASE)
+        if m_client:
+            pending_client_name = (m_client.group(1) or "").strip()
+            continue
+
+        if re.match(r"^\[Peer\]$", line, flags=re.IGNORECASE):
+            flush_peer(current_peer)
+            current_peer = {
+                "client_name": pending_client_name,
+                "peer_public_key": "",
+                "allowed_ips": "",
+            }
+            pending_client_name = ""
+            continue
+
+        if line.startswith("[") and line.endswith("]"):
+            flush_peer(current_peer)
+            current_peer = None
+            continue
+
+        if current_peer is None:
+            continue
+
+        m_pub = re.match(r"^PublicKey\s*=\s*(.+)$", line, flags=re.IGNORECASE)
+        if m_pub:
+            current_peer["peer_public_key"] = (m_pub.group(1) or "").strip()
+            continue
+
+        m_allowed = re.match(r"^AllowedIPs\s*=\s*(.+)$", line, flags=re.IGNORECASE)
+        if m_allowed:
+            current_peer["allowed_ips"] = (m_allowed.group(1) or "").strip()
+
+    flush_peer(current_peer)
+    return rows
+
+
+def load_wireguard_peer_cache_maps(conn: sqlite3.Connection) -> Tuple[Dict[Tuple[str, str], str], Dict[Tuple[str, str], str]]:
+    by_public_key: Dict[Tuple[str, str], str] = {}
+    by_allowed_ip: Dict[Tuple[str, str], str] = {}
+
+    try:
+        rows = conn.execute(
+            "SELECT interface_name, peer_public_key, client_name, allowed_ips FROM wireguard_peer_cache"
+        ).fetchall()
+    except sqlite3.Error:
+        rows = []
+
+    for row in rows:
+        interface_name = (row["interface_name"] or "").strip()
+        peer_public_key = (row["peer_public_key"] or "").strip()
+        client_name = (row["client_name"] or "").strip()
+        if not interface_name or not client_name:
+            continue
+
+        if peer_public_key:
+            by_public_key[(interface_name, peer_public_key)] = client_name
+
+        for ip in split_wireguard_allowed_ips(row["allowed_ips"] or ""):
+            by_allowed_ip[(interface_name, ip)] = client_name
+
+    return by_public_key, by_allowed_ip
+
+
+def sync_wireguard_peer_cache_from_configs(conn: sqlite3.Connection, wireguard_config_files: Dict[str, str]) -> int:
+    parsed_rows: List[Dict[str, Any]] = []
+    for interface_name, config_path in wireguard_config_files.items():
+        parsed_rows.extend(parse_wireguard_config_peer_rows(config_path, interface_name))
+
+    by_key: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for row in parsed_rows:
+        key = ((row.get("interface_name") or "").strip(), (row.get("peer_public_key") or "").strip())
+        if not key[0] or not key[1]:
+            continue
+        by_key[key] = row
+
+    existing_rows = conn.execute(
+        "SELECT id, interface_name, peer_public_key, client_name, allowed_ips FROM wireguard_peer_cache"
+    ).fetchall()
+    existing_by_key = {
+        ((row["interface_name"] or "").strip(), (row["peer_public_key"] or "").strip()): row
+        for row in existing_rows
+    }
+
+    for key, parsed in by_key.items():
+        existing = existing_by_key.pop(key, None)
+        parsed_name = (parsed.get("client_name") or "").strip()
+        parsed_allowed = (parsed.get("allowed_ips") or "").strip() or None
+        now = utcnow_sql()
+
+        if existing is None:
+            conn.execute(
+                """
+                INSERT INTO wireguard_peer_cache
+                    (interface_name, peer_public_key, client_name, allowed_ips, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (key[0], key[1], parsed_name, parsed_allowed, now),
+            )
+            continue
+
+        if (
+            ((existing["client_name"] or "").strip() != parsed_name)
+            or (((existing["allowed_ips"] or "").strip() or None) != parsed_allowed)
+        ):
+            conn.execute(
+                """
+                UPDATE wireguard_peer_cache
+                SET client_name = ?, allowed_ips = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (parsed_name, parsed_allowed, now, existing["id"]),
+            )
+
+    for stale_row in existing_by_key.values():
+        conn.execute("DELETE FROM wireguard_peer_cache WHERE id = ?", (stale_row["id"],))
+
+    return len(by_key)
+
+
+def collect_wireguard_status_rows(
+    conn: sqlite3.Connection,
+    wireguard_config_files: Dict[str, str],
+    active_handshake_seconds: int,
+) -> List[Dict[str, Any]]:
+    status_rows = {
+        "antizapret": {
+            "profile": "antizapret-wg",
+            "label": "Antizapret WG",
+            "protocol": "WireGuard",
+            "filename": "wg:antizapret",
+            "exists": False,
+            "clients": [],
+            "traffic_clients": [],
+        },
+        "vpn": {
+            "profile": "vpn-wg",
+            "label": "VPN WG",
+            "protocol": "WireGuard",
+            "filename": "wg:vpn",
+            "exists": False,
+            "clients": [],
+            "traffic_clients": [],
+        },
+    }
+
+    try:
+        result = subprocess.run(
+            ["wg", "show", "all", "dump"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=3,
+        )
+    except Exception:
+        result = None
+
+    if result is None or result.returncode != 0:
+        return list(status_rows.values())
+
+    now_dt = datetime.utcnow()
+    snapshot_time = now_dt.strftime("%Y-%m-%d %H:%M:%S")
+
+    parsed_peers: List[Dict[str, Any]] = []
+    for raw_line in (result.stdout or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        parts = line.split("\t")
+        if len(parts) == 5:
+            interface_name = (parts[0] or "").strip()
+            if interface_name in status_rows:
+                status_rows[interface_name]["exists"] = True
+                status_rows[interface_name]["snapshot_time"] = snapshot_time
+                status_rows[interface_name]["updated_at"] = snapshot_time
+            continue
+
+        if len(parts) < 8:
+            continue
+
+        interface_name = (parts[0] or "").strip()
+        if interface_name not in status_rows:
+            continue
+
+        status_rows[interface_name]["exists"] = True
+        status_rows[interface_name]["snapshot_time"] = snapshot_time
+        status_rows[interface_name]["updated_at"] = snapshot_time
+
+        try:
+            latest_handshake_ts = int(parts[5] or 0)
+        except (TypeError, ValueError):
+            latest_handshake_ts = 0
+        try:
+            bytes_received = int(parts[6] or 0)
+        except (TypeError, ValueError):
+            bytes_received = 0
+        try:
+            bytes_sent = int(parts[7] or 0)
+        except (TypeError, ValueError):
+            bytes_sent = 0
+
+        parsed_peers.append(
+            {
+                "interface": interface_name,
+                "peer_public_key": (parts[1] or "").strip(),
+                "endpoint": (parts[3] or "").strip(),
+                "allowed_ips": (parts[4] or "").strip(),
+                "latest_handshake_ts": latest_handshake_ts,
+                "bytes_received": max(bytes_received, 0),
+                "bytes_sent": max(bytes_sent, 0),
+            }
+        )
+
+    by_public_key, by_allowed_ip = load_wireguard_peer_cache_maps(conn)
+    missing_mapping = False
+    for peer in parsed_peers:
+        iface = peer.get("interface")
+        key = (iface, (peer.get("peer_public_key") or "").strip())
+        allowed_candidates = split_wireguard_allowed_ips(peer.get("allowed_ips") or "")
+        fallback_ip = allowed_candidates[0] if allowed_candidates else ""
+        if key in by_public_key:
+            continue
+        if fallback_ip and (iface, fallback_ip) in by_allowed_ip:
+            continue
+        missing_mapping = True
+        break
+
+    if missing_mapping:
+        sync_wireguard_peer_cache_from_configs(conn, wireguard_config_files)
+        by_public_key, by_allowed_ip = load_wireguard_peer_cache_maps(conn)
+
+    for peer in parsed_peers:
+        interface_name = peer.get("interface")
+        row = status_rows[interface_name]
+
+        allowed_ips = split_wireguard_allowed_ips(peer.get("allowed_ips") or "")
+        preferred_allowed_ip = allowed_ips[0] if allowed_ips else ""
+        peer_public_key = (peer.get("peer_public_key") or "").strip()
+
+        common_name = by_public_key.get((interface_name, peer_public_key))
+        if not common_name and preferred_allowed_ip:
+            common_name = by_allowed_ip.get((interface_name, preferred_allowed_ip))
+        if not common_name:
+            if preferred_allowed_ip:
+                common_name = f"{interface_name}-{preferred_allowed_ip}"
+            elif peer_public_key:
+                common_name = f"{interface_name}-{peer_public_key[:10]}"
+            else:
+                common_name = f"{interface_name}-peer"
+
+        endpoint = (peer.get("endpoint") or "").strip()
+        real_ip = extract_ip_from_wireguard_endpoint(endpoint)
+        latest_handshake_ts = int(peer.get("latest_handshake_ts") or 0)
+        connected_since = "-"
+        if latest_handshake_ts > 0:
+            try:
+                connected_since = datetime.fromtimestamp(latest_handshake_ts).strftime("%Y-%m-%d %H:%M:%S")
+            except Exception:
+                connected_since = "-"
+
+        client_payload = {
+            "common_name": common_name,
+            "real_address": endpoint if endpoint and endpoint != "(none)" else "-",
+            "real_ip": real_ip,
+            "virtual_address": preferred_allowed_ip or "-",
+            "peer_public_key": peer_public_key,
+            "session_kind": "wireguard",
+            "bytes_received": int(peer.get("bytes_received") or 0),
+            "bytes_sent": int(peer.get("bytes_sent") or 0),
+            "total_bytes": int(peer.get("bytes_received") or 0) + int(peer.get("bytes_sent") or 0),
+            "connected_since": connected_since,
+            "connected_since_ts": latest_handshake_ts,
+            "cipher": "WireGuard",
+        }
+
+        row["traffic_clients"].append(client_payload)
+        if is_wireguard_peer_active(latest_handshake_ts, active_handshake_seconds):
+            row["clients"].append(client_payload)
+
+    return [status_rows["antizapret"], status_rows["vpn"]]
+
+
+def collect_status_rows_for_snapshot(conn: sqlite3.Connection) -> List[Dict[str, Any]]:
+    logs_dir = os.getenv("LOGS_DIR", DEFAULT_LOGS_DIR)
+    status_log_files = {
+        "antizapret-tcp": os.path.join(logs_dir, "antizapret-tcp-status.log"),
+        "antizapret-udp": os.path.join(logs_dir, "antizapret-udp-status.log"),
+        "vpn-tcp": os.path.join(logs_dir, "vpn-tcp-status.log"),
+        "vpn-udp": os.path.join(logs_dir, "vpn-udp-status.log"),
+    }
+
+    wireguard_config_files = dict(DEFAULT_WIREGUARD_CONFIG_FILES)
+    active_seconds = env_int(
+        "WIREGUARD_ACTIVE_HANDSHAKE_SECONDS",
+        DEFAULT_WIREGUARD_ACTIVE_HANDSHAKE_SECONDS,
+        min_value=0,
+    )
+
+    rows = [parse_status_log(profile_key, filename) for profile_key, filename in status_log_files.items()]
+    rows.extend(collect_wireguard_status_rows(conn, wireguard_config_files, active_seconds))
+    return rows
+
+
+def normalize_traffic_protocol_type(protocol_type: str, fallback: str = "openvpn") -> str:
+    value = (protocol_type or fallback or "openvpn").strip().lower()
+    if value in {"wg", "wireguard", "amneziawg", "awg"}:
+        return "wireguard"
+    if value in {"openvpn", "ovpn"}:
+        return "openvpn"
+    return fallback
+
+
+def build_session_key(profile: str, client: Dict[str, Any]) -> str:
+    session_kind = (client.get("session_kind") or "").strip().lower()
+    if session_kind == "wireguard" or str(profile or "").endswith("-wg"):
+        common_name = (client.get("common_name") or "-").strip()
+        peer_public_key = (client.get("peer_public_key") or "-").strip()
+        virtual_address = (client.get("virtual_address") or "-").strip()
+        return f"{profile}|wg|{common_name}|{peer_public_key}|{virtual_address}"
+
+    common_name = (client.get("common_name") or "-").strip()
+    real_address = (client.get("real_address") or "-").strip()
+    virtual_address = (client.get("virtual_address") or "-").strip()
+    connected_since_ts = int(client.get("connected_since_ts") or 0)
+    return f"{profile}|{common_name}|{real_address}|{virtual_address}|{connected_since_ts}"
+
+
+def load_sessions_by_key(conn: sqlite3.Connection) -> Dict[str, sqlite3.Row]:
+    rows = conn.execute(
+        """
+        SELECT id, session_key, profile, common_name, real_address, virtual_address,
+               connected_since_ts, last_bytes_received, last_bytes_sent, is_active,
+               last_seen_at, ended_at
+        FROM traffic_session_state
+        """
+    ).fetchall()
+    return {row["session_key"]: row for row in rows}
+
+
+def load_stats_by_user(conn: sqlite3.Connection) -> Dict[Tuple[str, str], sqlite3.Row]:
+    rows = conn.execute(
+        """
+        SELECT id, common_name, protocol_type, total_received, total_sent,
+               total_received_vpn, total_sent_vpn,
+               total_received_antizapret, total_sent_antizapret,
+               total_sessions, first_seen_at, last_seen_at
+        FROM user_traffic_stat_protocol
+        """
+    ).fetchall()
+    return {
+        (
+            (row["common_name"] or "").strip(),
+            normalize_traffic_protocol_type(row["protocol_type"], fallback="openvpn"),
+        ): row
+        for row in rows
+    }
+
+
+def insert_session_state(
+    conn: sqlite3.Connection,
+    *,
+    session_key: str,
+    profile: str,
+    common_name: str,
+    client: Dict[str, Any],
+    current_rx: int,
+    current_tx: int,
+    now: str,
+) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO traffic_session_state
+            (session_key, profile, common_name, real_address, virtual_address,
+             connected_since_ts, last_bytes_received, last_bytes_sent,
+             is_active, last_seen_at, ended_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL)
+        """,
+        (
+            session_key,
+            profile,
+            common_name,
+            (client.get("real_address") or "").strip() or None,
+            (client.get("virtual_address") or "").strip() or None,
+            int(client.get("connected_since_ts") or 0),
+            current_rx,
+            current_tx,
+            now,
+        ),
+    )
+    return int(cur.lastrowid)
+
+
+def update_session_state(
+    conn: sqlite3.Connection,
+    *,
+    row_id: int,
+    current_rx: int,
+    current_tx: int,
+    now: str,
+) -> None:
+    conn.execute(
+        """
+        UPDATE traffic_session_state
+        SET last_bytes_received = ?,
+            last_bytes_sent = ?,
+            last_seen_at = ?,
+            is_active = 1,
+            ended_at = NULL
+        WHERE id = ?
+        """,
+        (current_rx, current_tx, now, row_id),
+    )
+
+
+def insert_stat_protocol(
+    conn: sqlite3.Connection,
+    *,
+    common_name: str,
+    protocol_type: str,
+    now: str,
+) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO user_traffic_stat_protocol
+            (common_name, protocol_type, total_received, total_sent,
+             total_received_vpn, total_sent_vpn,
+             total_received_antizapret, total_sent_antizapret,
+             total_sessions, first_seen_at, last_seen_at, updated_at)
+        VALUES (?, ?, 0, 0, 0, 0, 0, 0, 0, ?, ?, ?)
+        """,
+        (common_name, protocol_type, now, now, now),
+    )
+    return int(cur.lastrowid)
+
+
+def update_stat_protocol(
+    conn: sqlite3.Connection,
+    *,
+    row_id: int,
+    delta_rx: int,
+    delta_tx: int,
+    is_antizapret_profile: bool,
+    is_new_session: bool,
+    now: str,
+) -> None:
+    if is_antizapret_profile:
+        conn.execute(
+            """
+            UPDATE user_traffic_stat_protocol
+            SET total_received = COALESCE(total_received, 0) + ?,
+                total_sent = COALESCE(total_sent, 0) + ?,
+                total_received_antizapret = COALESCE(total_received_antizapret, 0) + ?,
+                total_sent_antizapret = COALESCE(total_sent_antizapret, 0) + ?,
+                total_sessions = COALESCE(total_sessions, 0) + ?,
+                last_seen_at = ?,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (delta_rx, delta_tx, delta_rx, delta_tx, 1 if is_new_session else 0, now, now, row_id),
+        )
+    else:
+        conn.execute(
+            """
+            UPDATE user_traffic_stat_protocol
+            SET total_received = COALESCE(total_received, 0) + ?,
+                total_sent = COALESCE(total_sent, 0) + ?,
+                total_received_vpn = COALESCE(total_received_vpn, 0) + ?,
+                total_sent_vpn = COALESCE(total_sent_vpn, 0) + ?,
+                total_sessions = COALESCE(total_sessions, 0) + ?,
+                last_seen_at = ?,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (delta_rx, delta_tx, delta_rx, delta_tx, 1 if is_new_session else 0, now, now, row_id),
+        )
+
+
+def insert_traffic_sample(
+    conn: sqlite3.Connection,
+    *,
+    common_name: str,
+    network_type: str,
+    protocol_type: str,
+    delta_rx: int,
+    delta_tx: int,
+    now: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO user_traffic_sample
+            (common_name, network_type, protocol_type, delta_received, delta_sent, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (common_name, network_type, protocol_type, delta_rx, delta_tx, now),
+    )
+
+
+def mark_inactive_sessions(
+    conn: sqlite3.Connection,
+    *,
+    active_before: Iterable[str],
+    seen_keys: Iterable[str],
+    now: str,
+) -> int:
+    active_before_set = set(active_before)
+    seen_set = set(seen_keys)
+    to_end = sorted(active_before_set - seen_set)
+    if not to_end:
+        return 0
+
+    conn.executemany(
+        """
+        UPDATE traffic_session_state
+        SET is_active = 0,
+            ended_at = ?
+        WHERE session_key = ? AND is_active = 1
+        """,
+        [(now, key) for key in to_end],
+    )
+    return len(to_end)
+
+
+def persist_traffic_snapshot(conn: sqlite3.Connection, status_rows: Sequence[Dict[str, Any]]) -> Dict[str, int]:
+    now = utcnow_sql()
+
+    sessions_by_key = load_sessions_by_key(conn)
+    previously_active_keys = {
+        key for key, row in sessions_by_key.items() if bool(row["is_active"])
+    }
+    stats_by_user = load_stats_by_user(conn)
+
+    seen_keys = set()
+    samples_inserted = 0
+    sessions_created = 0
+    sessions_updated = 0
+    stats_created = 0
+
+    for status_row in status_rows:
+        profile = status_row.get("profile", "unknown")
+        clients = status_row.get("traffic_clients", status_row.get("clients", []))
+        for client in clients:
+            session_key = build_session_key(profile, client)
+            if session_key in seen_keys:
+                continue
+            seen_keys.add(session_key)
+
+            current_rx = int(client.get("bytes_received") or 0)
+            current_tx = int(client.get("bytes_sent") or 0)
+            common_name = (client.get("common_name") or "-").strip()
+            is_antizapret_profile = str(profile).startswith("antizapret")
+            is_wireguard_profile = str(profile).endswith("-wg")
+            protocol_type = "wireguard" if is_wireguard_profile else "openvpn"
+
+            session_state = sessions_by_key.get(session_key)
+            is_new_session = session_state is None
+
+            if is_new_session:
+                row_id = insert_session_state(
+                    conn,
+                    session_key=session_key,
+                    profile=profile,
+                    common_name=common_name,
+                    client=client,
+                    current_rx=current_rx,
+                    current_tx=current_tx,
+                    now=now,
+                )
+                # Keep lightweight cache in sync for duplicate detection in the same run.
+                sessions_by_key[session_key] = {
+                    "id": row_id,
+                    "last_bytes_received": current_rx,
+                    "last_bytes_sent": current_tx,
+                    "is_active": 1,
+                }
+                sessions_created += 1
+
+                if is_wireguard_profile:
+                    # Same as original service: for a new WG key, current counters are baseline.
+                    delta_rx = 0
+                    delta_tx = 0
+                else:
+                    delta_rx = max(current_rx, 0)
+                    delta_tx = max(current_tx, 0)
+            else:
+                delta_rx = current_rx - int(session_state["last_bytes_received"] or 0)
+                delta_tx = current_tx - int(session_state["last_bytes_sent"] or 0)
+
+                if delta_rx < 0:
+                    delta_rx = max(current_rx, 0)
+                if delta_tx < 0:
+                    delta_tx = max(current_tx, 0)
+
+                update_session_state(
+                    conn,
+                    row_id=int(session_state["id"]),
+                    current_rx=current_rx,
+                    current_tx=current_tx,
+                    now=now,
+                )
+                sessions_updated += 1
+
+            delta_rx = max(delta_rx, 0)
+            delta_tx = max(delta_tx, 0)
+
+            stat_key = (common_name, protocol_type)
+            user_stat = stats_by_user.get(stat_key)
+            if user_stat is None:
+                stat_id = insert_stat_protocol(
+                    conn,
+                    common_name=common_name,
+                    protocol_type=protocol_type,
+                    now=now,
+                )
+                user_stat = {"id": stat_id}
+                stats_by_user[stat_key] = user_stat
+                stats_created += 1
+
+            update_stat_protocol(
+                conn,
+                row_id=int(user_stat["id"]),
+                delta_rx=delta_rx,
+                delta_tx=delta_tx,
+                is_antizapret_profile=is_antizapret_profile,
+                is_new_session=is_new_session,
+                now=now,
+            )
+
+            if delta_rx > 0 or delta_tx > 0:
+                insert_traffic_sample(
+                    conn,
+                    common_name=common_name,
+                    network_type="antizapret" if is_antizapret_profile else "vpn",
+                    protocol_type=protocol_type,
+                    delta_rx=delta_rx,
+                    delta_tx=delta_tx,
+                    now=now,
+                )
+                samples_inserted += 1
+
+    sessions_marked_inactive = mark_inactive_sessions(
+        conn,
+        active_before=previously_active_keys,
+        seen_keys=seen_keys,
+        now=now,
+    )
+
+    return {
+        "status_rows": len(status_rows),
+        "seen_sessions": len(seen_keys),
+        "sessions_created": sessions_created,
+        "sessions_updated": sessions_updated,
+        "sessions_marked_inactive": sessions_marked_inactive,
+        "stats_created": stats_created,
+        "samples_inserted": samples_inserted,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fast AdminAntizapret traffic snapshot sync.")
+    parser.add_argument("--db", default="", help="Path to users.db. Defaults to instance/users.db.")
+    parser.add_argument("--json", action="store_true", help="Print a compact JSON summary.")
+    parser.add_argument("--no-wg", action="store_true", help="Skip WireGuard status collection.")
+    parser.add_argument("--no-openvpn", action="store_true", help="Skip OpenVPN status log collection.")
+    return parser
+
+
+def run_sync(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    db_path = resolve_db_path(args.db)
+
+    if not db_path.exists():
+        print(json.dumps({"error": f"database not found: {db_path}"}, ensure_ascii=False), file=sys.stderr)
+        return 1
+
+    conn = connect_db(db_path)
+    try:
+        if args.no_openvpn and args.no_wg:
+            status_rows: List[Dict[str, Any]] = []
+        else:
+            if args.no_wg:
+                logs_dir = os.getenv("LOGS_DIR", DEFAULT_LOGS_DIR)
+                status_log_files = {
+                    "antizapret-tcp": os.path.join(logs_dir, "antizapret-tcp-status.log"),
+                    "antizapret-udp": os.path.join(logs_dir, "antizapret-udp-status.log"),
+                    "vpn-tcp": os.path.join(logs_dir, "vpn-tcp-status.log"),
+                    "vpn-udp": os.path.join(logs_dir, "vpn-udp-status.log"),
+                }
+                status_rows = [parse_status_log(profile_key, filename) for profile_key, filename in status_log_files.items()]
+            elif args.no_openvpn:
+                status_rows = collect_wireguard_status_rows(
+                    conn,
+                    DEFAULT_WIREGUARD_CONFIG_FILES,
+                    env_int(
+                        "WIREGUARD_ACTIVE_HANDSHAKE_SECONDS",
+                        DEFAULT_WIREGUARD_ACTIVE_HANDSHAKE_SECONDS,
+                        min_value=0,
+                    ),
+                )
+            else:
+                status_rows = collect_status_rows_for_snapshot(conn)
+
+        with conn:
+            summary = persist_traffic_snapshot(conn, status_rows)
+
+        if args.json:
+            print(json.dumps({"ok": True, "db": str(db_path), **summary}, ensure_ascii=False))
+        return 0
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":
     try:
         sys.exit(run_sync())
     except Exception as exc:
-        logger.exception("traffic_sync failed: %s", exc)
+        print(json.dumps({"error": str(exc)}, ensure_ascii=False), file=sys.stderr)
         sys.exit(1)

--- a/utils/wg_awg_runtime_apply.py
+++ b/utils/wg_awg_runtime_apply.py
@@ -1,20 +1,325 @@
 #!/usr/bin/env python3
+"""Fast WG/AWG runtime block/unblock CLI.
+
+This entrypoint intentionally does NOT import app.py, Flask, Flask-SQLAlchemy,
+route wiring, schedulers, migrations, monitors, or the big service container.
+
+It only needs:
+  * client name/action from CLI;
+  * WireGuard config file locations;
+  * optional peer cache from SQLite table wireguard_peer_cache;
+  * peer specs parsed from existing wg/awg config files;
+  * wg/wg-quick subprocess calls.
+"""
+
 import argparse
 import json
 import logging
 import os
+import sqlite3
+import subprocess
 import sys
-
-_APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _APP_ROOT not in sys.path:
-    sys.path.insert(0, _APP_ROOT)
-
-# Не запускать reconcile/cron при импорте app.py — иначе CLI блокируется на десятки секунд.
-os.environ.setdefault("ADMIN_ANTIZAPRET_SKIP_APP_BOOTSTRAP", "1")
+import tempfile
+from pathlib import Path
 
 
-def _build_parser():
-    parser = argparse.ArgumentParser(description="Apply WG/AWG runtime block or unblock for one client.")
+APP_ROOT = Path(__file__).resolve().parents[1]
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+ENV_FILE_PATH = APP_ROOT / ".env"
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 4
+
+# Keep these defaults aligned with RuntimeSettingsService.WIREGUARD_CONFIG_FILES.
+DEFAULT_WIREGUARD_CONFIG_FILES = {
+    "antizapret": "/etc/wireguard/antizapret.conf",
+    "vpn": "/etc/wireguard/vpn.conf",
+}
+
+
+def _load_dotenv_light(path: Path) -> None:
+    """Tiny .env loader to avoid importing python-dotenv just for this CLI."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logging.warning("Could not read .env file %s: %s", path, exc)
+        return
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        os.environ.setdefault(key, value)
+
+
+def _env_int(key: str, default: int, *, min_value: int | None = None) -> int:
+    try:
+        value = int(os.getenv(key, str(default)))
+    except (TypeError, ValueError):
+        value = int(default)
+    if min_value is not None and value < min_value:
+        value = min_value
+    return value
+
+
+def _resolve_sqlite_db_path() -> Path:
+    """Resolve Flask-SQLAlchemy sqlite:///users.db path without creating Flask app.
+
+    Flask-SQLAlchemy resolves relative sqlite paths under app.instance_path by
+    default, so /opt/AdminAntizapret/instance/users.db is the expected path.
+    A fallback to APP_ROOT/users.db is kept for older/manual deployments.
+    """
+    env_url = (os.getenv("SQLALCHEMY_DATABASE_URI") or os.getenv("DATABASE_URL") or "").strip()
+    if env_url.startswith("sqlite:////"):
+        return Path(env_url.removeprefix("sqlite:///"))
+    if env_url.startswith("sqlite:///"):
+        rel = env_url.removeprefix("sqlite:///")
+        # Match Flask-SQLAlchemy's behavior for relative sqlite paths.
+        return APP_ROOT / "instance" / rel
+
+    candidates = [
+        APP_ROOT / "instance" / "users.db",
+        APP_ROOT / "users.db",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def _run(args: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _normalize_client_name(client_name: str) -> str:
+    return (client_name or "").strip().lower()
+
+
+def _wireguard_config_files() -> dict[str, str]:
+    """Return WireGuard/AWG config files.
+
+    RuntimeSettingsService currently returns static paths for this setting, so
+    importing it would be unnecessary overhead. Optional env overrides are here
+    for safe future customization without app.py imports.
+    """
+    return {
+        "antizapret": os.getenv("WIREGUARD_ANTIZAPRET_CONFIG", DEFAULT_WIREGUARD_CONFIG_FILES["antizapret"]),
+        "vpn": os.getenv("WIREGUARD_VPN_CONFIG", DEFAULT_WIREGUARD_CONFIG_FILES["vpn"]),
+    }
+
+
+def _collect_peer_specs_from_configs(wireguard_config_files: dict[str, str], client_name: str) -> list[dict]:
+    try:
+        from utils.wg_config_peers import collect_client_peer_specs
+    except Exception as exc:
+        logging.warning("Could not import utils.wg_config_peers: %s", exc)
+        return []
+
+    try:
+        return list(collect_client_peer_specs(wireguard_config_files, client_name) or [])
+    except Exception as exc:
+        logging.warning("Could not collect peer specs from configs for %s: %s", client_name, exc)
+        return []
+
+
+def _collect_client_peers_from_cache(client_name: str) -> list[tuple[str, str]]:
+    normalized = _normalize_client_name(client_name)
+    if not normalized:
+        return []
+
+    db_path = _resolve_sqlite_db_path()
+    if not db_path.exists():
+        logging.warning("SQLite DB not found at %s; falling back to config parsing", db_path)
+        return []
+
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=30)
+        try:
+            rows = conn.execute(
+                """
+                SELECT interface_name, peer_public_key
+                FROM wireguard_peer_cache
+                WHERE lower(client_name) = ?
+                """,
+                (normalized,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        logging.warning("Could not read wireguard_peer_cache from %s: %s", db_path, exc)
+        return []
+
+    peers: list[tuple[str, str]] = []
+    for interface_name, peer_public_key in rows:
+        iface = (interface_name or "").strip()
+        key = (peer_public_key or "").strip()
+        if iface and key:
+            peers.append((iface, key))
+    return peers
+
+
+def _collect_client_peers(client_name: str, wireguard_config_files: dict[str, str]) -> list[tuple[str, str]]:
+    peers = _collect_client_peers_from_cache(client_name)
+    if peers:
+        return peers
+
+    return [
+        (spec["interface_name"], spec["peer_public_key"])
+        for spec in _collect_peer_specs_from_configs(wireguard_config_files, client_name)
+        if spec.get("interface_name") and spec.get("peer_public_key")
+    ]
+
+
+def _sync_interface_from_stripped_config(interface_name: str, *, timeout: int) -> tuple[bool, str]:
+    strip_result = _run(["wg-quick", "strip", interface_name], timeout=timeout)
+    if strip_result.returncode != 0:
+        return False, (strip_result.stderr or "").strip()
+
+    stripped_config = strip_result.stdout or ""
+    if not stripped_config.strip():
+        return False, "empty stripped config"
+
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as temp_file:
+            temp_file.write(stripped_config)
+            temp_path = temp_file.name
+        sync_result = _run(["wg", "syncconf", interface_name, temp_path], timeout=timeout)
+        if sync_result.returncode == 0:
+            return True, ""
+        return False, (sync_result.stderr or "").strip()
+    finally:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+
+
+def _restore_peer_spec(spec: dict, *, timeout: int) -> tuple[bool, str]:
+    interface_name = (spec.get("interface_name") or "").strip()
+    peer_public_key = (spec.get("peer_public_key") or "").strip()
+    if not interface_name or not peer_public_key:
+        return False, "missing interface or public key"
+
+    args = ["wg", "set", interface_name, "peer", peer_public_key]
+    allowed_ips = (spec.get("allowed_ips") or "").strip()
+    if allowed_ips:
+        args.extend(["allowed-ips", allowed_ips])
+
+    preshared_key = (spec.get("preshared_key") or "").strip()
+    psk_path = None
+    try:
+        if preshared_key:
+            with tempfile.NamedTemporaryFile(mode="wb", suffix=".psk", delete=False) as psk_file:
+                psk_file.write(preshared_key.encode("ascii"))
+                psk_path = psk_file.name
+            args.extend(["preshared-key", psk_path])
+
+        result = _run(args, timeout=timeout)
+        if result.returncode == 0:
+            return True, ""
+        return False, (result.stderr or "").strip()
+    finally:
+        if psk_path:
+            try:
+                os.unlink(psk_path)
+            except OSError:
+                pass
+
+
+def block_client_runtime(client_name: str, *, wireguard_config_files: dict[str, str], timeout: int) -> dict:
+    peers = _collect_client_peers(client_name, wireguard_config_files)
+    removed = []
+    errors = []
+
+    for interface_name, peer_public_key in peers:
+        result = _run(["wg", "set", interface_name, "peer", peer_public_key, "remove"], timeout=timeout)
+        if result.returncode == 0:
+            removed.append((interface_name, peer_public_key))
+        else:
+            errors.append(
+                {
+                    "interface": interface_name,
+                    "peer_public_key": peer_public_key,
+                    "stderr": (result.stderr or "").strip(),
+                }
+            )
+
+    return {
+        "removed_count": len(removed),
+        "error_count": len(errors),
+        "errors": errors,
+    }
+
+
+def unblock_client_runtime(client_name: str, *, wireguard_config_files: dict[str, str], timeout: int) -> dict:
+    specs = _collect_peer_specs_from_configs(wireguard_config_files, client_name)
+    restored = []
+    errors = []
+
+    if specs:
+        for spec in specs:
+            ok, stderr = _restore_peer_spec(spec, timeout=timeout)
+            if ok:
+                restored.append(spec.get("interface_name"))
+            else:
+                errors.append(
+                    {
+                        "interface": spec.get("interface_name"),
+                        "stderr": stderr,
+                    }
+                )
+        return {
+            "synced_count": len(restored),
+            "error_count": len(errors),
+            "errors": errors,
+        }
+
+    peers = _collect_client_peers(client_name, wireguard_config_files)
+    interfaces = sorted({iface for iface, _ in peers if iface})
+    if not interfaces:
+        interfaces = sorted(wireguard_config_files.keys())
+
+    synced = []
+    for interface_name in interfaces:
+        if not (wireguard_config_files.get(interface_name) or "").strip():
+            continue
+        ok, stderr = _sync_interface_from_stripped_config(interface_name, timeout=timeout)
+        if ok:
+            synced.append(interface_name)
+        else:
+            errors.append(
+                {
+                    "interface": interface_name,
+                    "stderr": stderr,
+                }
+            )
+
+    return {
+        "synced_count": len(synced),
+        "error_count": len(errors),
+        "errors": errors,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Apply WG/AWG runtime block or unblock for one client without importing app.py.")
     parser.add_argument("--client", required=True, help="WireGuard client name")
     parser.add_argument(
         "--action",
@@ -22,35 +327,36 @@ def _build_parser():
         choices=("block", "unblock"),
         help="Runtime action to apply",
     )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        help="Timeout in seconds for each wg/wg-quick command",
+    )
     return parser
 
 
-def main(argv=None):
+def main(argv=None) -> int:
+    _load_dotenv_light(ENV_FILE_PATH)
+
     args = _build_parser().parse_args(argv)
     client_name = (args.client or "").strip()
     action = (args.action or "").strip().lower()
+    timeout = max(1, int(args.timeout or DEFAULT_COMMAND_TIMEOUT_SECONDS))
 
     if not client_name:
         logging.error("Client name is required")
         print(json.dumps({"error": "client name is required"}, ensure_ascii=False))
         return 2
 
-    try:
-        from app import wg_awg_runtime_enforcer
-    except Exception as exc:
-        logging.exception("Failed to import WG runtime enforcer: %s", exc)
-        print(json.dumps({"error": str(exc)}, ensure_ascii=False))
-        return 2
+    wireguard_config_files = _wireguard_config_files()
 
     try:
-        from app import app
-
-        with app.app_context():
-            normalized = client_name.strip().lower()
-            if action == "block":
-                result = wg_awg_runtime_enforcer.block_client_runtime(normalized)
-            else:
-                result = wg_awg_runtime_enforcer.unblock_client_runtime(normalized)
+        normalized = _normalize_client_name(client_name)
+        if action == "block":
+            result = block_client_runtime(normalized, wireguard_config_files=wireguard_config_files, timeout=timeout)
+        else:
+            result = unblock_client_runtime(normalized, wireguard_config_files=wireguard_config_files, timeout=timeout)
     except Exception as exc:
         logging.exception("WG runtime apply failed for client=%s action=%s: %s", client_name, action, exc)
         print(json.dumps({"error": str(exc)}, ensure_ascii=False))
@@ -62,6 +368,7 @@ def main(argv=None):
         **(result or {}),
     }
     print(json.dumps(payload, ensure_ascii=False))
+
     error_count = int((result or {}).get("error_count") or 0)
     return 1 if error_count > 0 else 0
 


### PR DESCRIPTION
# Оптимизация runtime CLI-скриптов без импорта полного app.py

## Что сделано

В этом PR оптимизированы runtime/cron CLI-скрипты AdminAntizapret:

* `utils/wg_awg_runtime_apply.py`
* `utils/traffic_sync.py`

Обе реализации переписаны так, чтобы больше не импортировать полный `app.py` ради небольших фоновых операций.

Раньше каждый запуск этих скриптов поднимал значительную часть Flask-приложения: routes, сервисы, Flask app context, SQLAlchemy-модели, bootstrap-логику и другие зависимости. На слабых VPS это создавало заметную CPU-нагрузку и задержки.

Теперь скрипты выполняют только минимально необходимую работу напрямую.

## Почему это нужно

Старые версии были слишком тяжёлыми для cron/runtime-вызовов.

До оптимизации:

```text
wg_awg_runtime_apply.py unblock:
  wall time: ~10.35s
  max RSS:   ~70 MB

wg_awg_runtime_apply.py block:
  wall time: ~11.05s
  max RSS:   ~70 MB

traffic_sync.py:
  wall time: ~15.38s
  max RSS:   ~70 MB
```

После оптимизации:

```text
wg_awg_runtime_apply.py unblock:
  wall time: ~1.29s
  max RSS:   ~16 MB

wg_awg_runtime_apply.py block:
  wall time: ~0.79s
  max RSS:   ~16 MB

traffic_sync.py --json:
  wall time: ~0.46s
  max RSS:   ~18 MB
```

Итоговое ускорение:

```text
WG/AWG unblock: ~8x быстрее
WG/AWG block:   ~14x быстрее
traffic_sync:   ~33x быстрее
```

## Изменения в wg_awg_runtime_apply.py

Скрипт больше не импортирует `app.py`.

Новая версия:

* читает `wireguard_peer_cache` напрямую из SQLite;
* использует `/opt/AdminAntizapret/instance/users.db` как основной путь к БД;
* сохраняет fallback на `/opt/AdminAntizapret/users.db`;
* для `block` удаляет peer через:

```bash
wg set <interface> peer <public_key> remove
```

* для `unblock` восстанавливает peer из WireGuard-конфигов;
* при необходимости использует fallback через:

```bash
wg-quick strip <interface>
wg syncconf <interface> <temp_config>
```

JSON-формат ответа сохранён:

```json
{
  "client_name": "client",
  "action": "block",
  "removed_count": 2,
  "error_count": 0,
  "errors": []
}
```

и:

```json
{
  "client_name": "client",
  "action": "unblock",
  "synced_count": 2,
  "error_count": 0,
  "errors": []
}
```

## Изменения в traffic_sync.py

Скрипт больше не импортирует `app.py`, Flask и SQLAlchemy.

Новая версия напрямую:

* читает OpenVPN `*-status.log`;
* читает WireGuard runtime-состояние через:

```bash
wg show all dump
```

* при необходимости обновляет `wireguard_peer_cache` из WireGuard-конфигов;
* сохраняет дельты трафика в SQLite-таблицы:

  * `traffic_session_state`
  * `user_traffic_stat_protocol`
  * `user_traffic_sample`

Сохранена важная логика старой реализации:

* для новых OpenVPN-сессий текущие счётчики учитываются как трафик новой сессии;
* для новых WireGuard-сессий текущие счётчики считаются baseline, чтобы не засчитать уже накопленные счётчики интерфейса как новый трафик клиента;
* для существующих сессий сохраняется только дельта между предыдущим и текущим значением счётчиков;
* если счётчик сбросился, текущее значение считается новой дельтой;
* неактивные сессии помечаются как завершённые.

Пример успешного запуска:

```json
{
  "ok": true,
  "db": "/opt/AdminAntizapret/instance/users.db",
  "status_rows": 6,
  "seen_sessions": 30,
  "sessions_created": 0,
  "sessions_updated": 30,
  "sessions_marked_inactive": 0,
  "stats_created": 0,
  "samples_inserted": 5
}
```

## Совместимость

Оригинальные имена файлов сохранены:

```text
utils/wg_awg_runtime_apply.py
utils/traffic_sync.py
```

Поэтому cron и существующие вызовы не нужно переводить на новые пути.

Для `wg_awg_runtime_apply.py` сохранены аргументы:

```bash
--client <client_name>
--action block|unblock
```

Для `traffic_sync.py` добавлен полезный режим диагностики:

```bash
--json
```

Также добавлены режимы частичной проверки:

```bash
--no-wg
--no-openvpn
```

## Проверка

Проверка синтаксиса:

```bash
/opt/AdminAntizapret/venv/bin/python3 -m py_compile /opt/AdminAntizapret/utils/wg_awg_runtime_apply.py
/opt/AdminAntizapret/venv/bin/python3 -m py_compile /opt/AdminAntizapret/utils/traffic_sync.py
```

Проверка WG/AWG block/unblock:

```bash
/usr/bin/time -v /opt/AdminAntizapret/venv/bin/python3 /opt/AdminAntizapret/utils/wg_awg_runtime_apply.py --client scarman-p --action unblock
/usr/bin/time -v /opt/AdminAntizapret/venv/bin/python3 /opt/AdminAntizapret/utils/wg_awg_runtime_apply.py --client scarman-p --action block
```

Ожидаемый результат:

* exit code `0`;
* `error_count: 0`;
* для unblock возвращается `synced_count`;
* для block возвращается `removed_count`;
* состояние peer’ов подтверждается через `wg show`.

Проверка traffic sync:

```bash
/usr/bin/time -v /opt/AdminAntizapret/venv/bin/python3 /opt/AdminAntizapret/utils/traffic_sync.py --json
```

Ожидаемый результат:

* exit code `0`;
* JSON содержит `"ok": true`;
* обновляются `traffic_session_state`, `user_traffic_stat_protocol`, `user_traffic_sample`;
* время выполнения на тестовой VPS снизилось примерно с `15.38s` до `0.46s`.

Дополнительные проверки:

```bash
/opt/AdminAntizapret/venv/bin/python3 /opt/AdminAntizapret/utils/traffic_sync.py --json --no-wg
/opt/AdminAntizapret/venv/bin/python3 /opt/AdminAntizapret/utils/traffic_sync.py --json --no-openvpn
```

## Риски

Новая реализация обходит Flask/SQLAlchemy и работает с SQLite напрямую. Это сделано намеренно для уменьшения накладных расходов в cron/runtime CLI.

Основные риски:

* возможное расхождение с будущими изменениями SQLAlchemy-моделей;
* нужно следить за изменениями схемы таблиц:

  * `wireguard_peer_cache`
  * `traffic_session_state`
  * `user_traffic_stat_protocol`
  * `user_traffic_sample`

Для текущей схемы поведение проверено вручную на реальных вызовах `block`, `unblock` и `traffic_sync`.

## Результат

PR существенно снижает нагрузку от runtime CLI/cron-задач на VPS:

```text
WG/AWG runtime apply:
  ~10–11s -> ~0.8–1.3s

Traffic sync:
  ~15.4s -> ~0.46s

RAM:
  ~70 MB -> ~16–18 MB
```

Основная причина ускорения — удаление импорта полного `app.py` из CLI-скриптов.
